### PR TITLE
Add org.xen.xcp.storage.rawnfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DATAPATH_COMMANDS=Datapath.activate  Datapath.attach  Datapath.deactivate  Datapath.detach
 FFS_COMMANDS=Plugin.Query Plugin.diagnostics SR.create SR.ls SR.destroy SR.attach SR.detach Volume.create Volume.destroy Volume.stat Volume.clone Volume.snapshot Volume.resize
 BTRFS_COMMANDS=Plugin.Query Plugin.diagnostics SR.create SR.ls SR.destroy SR.attach SR.detach Volume.create Volume.destroy Volume.stat Volume.clone Volume.snapshot Volume.resize common.py
+RAWNFS_COMMANDS=Plugin.Query Plugin.diagnostics SR.create SR.ls SR.destroy SR.attach SR.detach Volume.create Volume.destroy Volume.stat Volume.resize common.py
 LIB_FILES=losetup.py tapdisk.py dmsetup.py nbdclient.py nbdtool.py image.py common.py
 
 .PHONY: clean
@@ -20,5 +21,7 @@ install:
 	(cd volume/org.xen.xcp.storage.ffs; install -m 0755 $(FFS_COMMANDS) $(DESTDIR)$(SCRIPTDIR)/volume/org.xen.xcp.storage.ffs)
 	mkdir -p $(DESTDIR)$(SCRIPTDIR)/volume/org.xen.xcp.storage.btrfs
 	(cd volume/org.xen.xcp.storage.btrfs; install -m 0755 $(BTRFS_COMMANDS) $(DESTDIR)$(SCRIPTDIR)/volume/org.xen.xcp.storage.btrfs)
+	mkdir -p $(DESTDIR)$(SCRIPTDIR)/volume/org.xen.xcp.storage.rawnfs
+	(cd volume/org.xen.xcp.storage.rawnfs; install -m 0755 $(RAWNFS_COMMANDS) $(DESTDIR)$(SCRIPTDIR)/volume/org.xen.xcp.storage.rawnfs)
 	mkdir -p $(DESTDIR)$(PYTHONDIR)
 	(cd lib; install -m 0755 $(LIB_FILES) $(DESTDIR)$(PYTHONDIR)/)

--- a/volume/org.xen.xcp.storage.rawnfs/Plugin.Query
+++ b/volume/org.xen.xcp.storage.rawnfs/Plugin.Query
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import xapi
+import xapi.plugin
+
+
+class Implementation(xapi.plugin.Plugin_skeleton):
+
+    def query(self, dbg):
+        return {
+            "plugin": "rawnfs",
+            "name": "NFS Raw Volume plugin",
+            "description": ("This plugin attaches a remote NFS and puts "
+                            "raw files onto it."),
+            "vendor": "None",
+            "copyright": "(C) 2016 Citrix Inc",
+            "version": "0.1",
+            "required_api_version": "0.1",
+            "features": [
+                "SR_ATTACH",
+                "SR_DETACH",
+                "SR_CREATE",
+                "VDI_CREATE",
+                "VDI_DESTROY",
+                "VDI_ATTACH",
+                "VDI_DETACH",
+                "VDI_ACTIVATE",
+                "VDI_DEACTIVATE"
+                "VDI_RESIZE"],
+            "configuration": {}}
+
+if __name__ == "__main__":
+    cmd = xapi.plugin.Plugin_commandline(Implementation())
+    cmd.query()

--- a/volume/org.xen.xcp.storage.rawnfs/Plugin.diagnostics
+++ b/volume/org.xen.xcp.storage.rawnfs/Plugin.diagnostics
@@ -1,0 +1,1 @@
+../org.xen.xcp.storage.ffs/Plugin.diagnostics

--- a/volume/org.xen.xcp.storage.rawnfs/SR.attach
+++ b/volume/org.xen.xcp.storage.rawnfs/SR.attach
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+from common import mountpoint_root
+import errno
+import urlparse
+import os
+import os.path
+import subprocess
+import xapi
+import xapi.volume
+
+
+class Implementation(xapi.volume.SR_skeleton):
+
+    def attach(self, dbg, uri):
+        u = urlparse.urlparse(uri)
+        mountpoint = mountpoint_root + "/" + u.netloc + "/" + u.path
+        try:
+            os.makedirs(mountpoint)
+        except OSError as exc:
+            if exc.errno == errno.EEXIST and os.path.isdir(mountpoint):
+                pass
+            else:
+                raise
+        cmd = ["mount", "-t", "nfs",
+               "-o", "acdirmin=0,acdirmax=0",
+               u.netloc + ":" + u.path, mountpoint]
+        code = subprocess.call(cmd)
+        if code != 0:
+            raise xapi.volume.Unimplemented(" ".join(cmd) + " failed")
+        uri = "file://" + mountpoint
+        return uri
+
+if __name__ == "__main__":
+    cmd = xapi.volume.SR_commandline(Implementation())
+    cmd.attach()

--- a/volume/org.xen.xcp.storage.rawnfs/SR.create
+++ b/volume/org.xen.xcp.storage.rawnfs/SR.create
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import urlparse
+import xapi
+import xapi.volume
+
+
+class Implementation(xapi.volume.SR_skeleton):
+
+    def create(self, dbg, uri, configuration):
+        u = urlparse.urlparse(uri)
+        if (u.scheme != "nfs" or not u.netloc or not u.path):
+            raise xapi.volume.SR_does_not_exist(
+                "The SR URI %s is invalid. " % (uri) +
+                "Please provide the URI as nfs://<host><path>"
+            )
+        return
+
+if __name__ == "__main__":
+    cmd = xapi.volume.SR_commandline(Implementation())
+    cmd.create()

--- a/volume/org.xen.xcp.storage.rawnfs/SR.destroy
+++ b/volume/org.xen.xcp.storage.rawnfs/SR.destroy
@@ -1,0 +1,1 @@
+../org.xen.xcp.storage.ffs/SR.destroy

--- a/volume/org.xen.xcp.storage.rawnfs/SR.detach
+++ b/volume/org.xen.xcp.storage.rawnfs/SR.detach
@@ -1,0 +1,1 @@
+../org.xen.xcp.storage.btrfs/SR.detach

--- a/volume/org.xen.xcp.storage.rawnfs/SR.ls
+++ b/volume/org.xen.xcp.storage.rawnfs/SR.ls
@@ -1,0 +1,1 @@
+../org.xen.xcp.storage.ffs/SR.ls

--- a/volume/org.xen.xcp.storage.rawnfs/SR.stat
+++ b/volume/org.xen.xcp.storage.rawnfs/SR.stat
@@ -1,0 +1,1 @@
+../org.xen.xcp.storage.ffs/SR.stat

--- a/volume/org.xen.xcp.storage.rawnfs/Volume.create
+++ b/volume/org.xen.xcp.storage.rawnfs/Volume.create
@@ -1,0 +1,1 @@
+../org.xen.xcp.storage.ffs/Volume.create

--- a/volume/org.xen.xcp.storage.rawnfs/Volume.destroy
+++ b/volume/org.xen.xcp.storage.rawnfs/Volume.destroy
@@ -1,0 +1,1 @@
+../org.xen.xcp.storage.ffs/Volume.destroy

--- a/volume/org.xen.xcp.storage.rawnfs/Volume.resize
+++ b/volume/org.xen.xcp.storage.rawnfs/Volume.resize
@@ -1,0 +1,1 @@
+../org.xen.xcp.storage.ffs/Volume.resize

--- a/volume/org.xen.xcp.storage.rawnfs/Volume.stat
+++ b/volume/org.xen.xcp.storage.rawnfs/Volume.stat
@@ -1,0 +1,1 @@
+../org.xen.xcp.storage.ffs/Volume.stat

--- a/volume/org.xen.xcp.storage.rawnfs/common.py
+++ b/volume/org.xen.xcp.storage.rawnfs/common.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+# For a nfs share at nfs://server/a/b/c, we will mount it at
+# <mountpoint_root>/server/a/b/c
+mountpoint_root = "/var/run/sr-mount/nfs/"


### PR DESCRIPTION
This is the first draft of a simple shared NFS Volume type. It's
without Volume.clone and Volume.snapshot for now.

This is because these operations definitely require suspending the
datapath, as we need to do a full copy of images. I'll approach
these next.

Signed-off-by: Robert Breker <robert.breker@citrix.com>