### PR TITLE
Update SR.stat to latest interface revision

### DIFF
--- a/volume/org.xen.xcp.storage.ffs/SR.stat
+++ b/volume/org.xen.xcp.storage.ffs/SR.stat
@@ -10,19 +10,16 @@ class Implementation(xapi.volume.SR_skeleton):
 
     def stat(self, dbg, sr):
         u = urlparse.urlparse(sr)
-        virtual_allocation = 0
-        for fpath in os.listdir(u.path):
-            fpath = os.path.join(u.path, fpath)
-            if os.path.isfile(fpath):
-                virtual_allocation += os.stat(fpath).st_size
         statvfs = os.statvfs(u.path)
         physical_size = statvfs.f_blocks * statvfs.f_frsize
         free_size = statvfs.f_bfree * statvfs.f_frsize
-        physical_utilisation = physical_size - free_size
         return {
-            "virtual_allocation": virtual_allocation,
-            "physical_utilisation": physical_utilisation,
-            "physical_size": physical_size}
+            "sr": sr,
+            "name": "This SR has no name",
+            "description": "This SR has no description",
+            "total_space": physical_size,
+            "free_space": free_size
+        }
 
 if __name__ == "__main__":
     cmd = xapi.volume.SR_commandline(Implementation())


### PR DESCRIPTION
In particular xapi is now performing the sum of virtual sizes, and
subtracting the free space from the total space to compute the used
space.

Signed-off-by: David Scott <dave.scott@eu.citrix.com>