### PR TITLE
Extend xapi.common.call to also return stderr and rc

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -10,12 +10,15 @@ import subprocess
 def log(txt):
     print >>sys.stderr, txt
 
-# [call dbg cmd_args] executes [cmd_args], throwing a BackendError if exits with
-# a non-zero exit code.
-def call(dbg, cmd_args):
+# [call dbg cmd_args] executes [cmd_args]
+# if [error] and a non-zero exit code, log and throws a BackendError
+# if [simple], returns only stdout
+def call(dbg, cmd_args, error=True, simple=True):
     p = subprocess.Popen(cmd_args, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
-    stdout, stderr = p.communicate ()
-    if p.returncode <> 0:
+    stdout, stderr = p.communicate()
+    if error and p.returncode != 0:
         log("%s: %s exitted with code %d: %s" % (dbg, " ".join(cmd_args), p.returncode, stderr))
         raise (xapi.InternalError("%s exitted with non-zero code %d: %s" % (" ".join(cmd_args), p.returncode, stderr)))
-    return stdout
+    if simple:
+        return stdout
+    return stdout, stderr, p.returncode


### PR DESCRIPTION
This patch enhances xapi.common.call() in a way that existing calls to
call() don't have to be changed. You can pass "errors=False" to disable
checking for non-zero exit codes. You can pass "simple=False" to also
get stderr and the return code.

Signed-off-by: Felipe Franciosi <felipe@paradoxo.org>