### PR TITLE
Volume.clone: the primary key should be the filename, not URI

### DIFF
--- a/volume/org.xen.xcp.storage.ffs/Volume.clone
+++ b/volume/org.xen.xcp.storage.ffs/Volume.clone
@@ -42,7 +42,7 @@ class Implementation(xapi.volume.Volume_skeleton):
                     raise
 
         stat = os.stat(new_name)
-        key = "file://" + new_name
+        key = os.path.basename(new_name)
         size = stat.st_size
         return {
             "key": key,


### PR DESCRIPTION
To discover the URIs, the client performs a Volume.stat providing the
key. The client then calls Datapath.attach with a URI from Volume.stat.

Signed-off-by: David Scott <dave.scott@eu.citrix.com>