### PR TITLE
Make tapdisk datapath use tapdisk3 rather than blkback

### DIFF
--- a/datapath/tapdisk/Datapath.attach
+++ b/datapath/tapdisk/Datapath.attach
@@ -20,7 +20,7 @@ class Implementation(xapi.datapath.Datapath_skeleton):
         tap.open(dbg, img)
         return {
             'domain_uuid': '0',
-            'implementation': [ 'Blkback', tap.block_device() ],
+            'implementation': [ 'Tapdisk3', tap.block_device() ],
         }
 
 if __name__ == "__main__":


### PR DESCRIPTION
Until now, the tapdisk datapath was using the "traditional" Clearwater
datapath (blkfront-blkback-blktap2-tapdisk). This patch makes use of
Creedence datapath (blkfront-tapdisk3).

Signed-off-by: Felipe Franciosi <felipe@paradoxo.org>