### PR TITLE
Implement VDI_SNAPSHOT for GFS2 SR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DATAPATH_COMMANDS=Datapath.activate  Datapath.attach  Datapath.deactivate  Datap
 FFS_COMMANDS=Plugin.Query Plugin.diagnostics SR.create SR.ls SR.destroy SR.attach SR.detach SR.stat Volume.create Volume.destroy Volume.stat Volume.clone Volume.snapshot Volume.resize
 BTRFS_COMMANDS=Plugin.Query Plugin.diagnostics SR.create SR.ls SR.destroy SR.attach SR.detach SR.stat Volume.create Volume.destroy Volume.stat Volume.clone Volume.snapshot Volume.resize common.py
 RAWNFS_COMMANDS=Plugin.Query Plugin.diagnostics SR.create SR.ls SR.destroy SR.attach SR.detach SR.stat Volume.create Volume.destroy Volume.stat Volume.resize common.py
-GFS2_COMMANDS=Plugin.Query Plugin.diagnostics SR.create SR.ls SR.destroy SR.attach SR.detach SR.stat Volume.create Volume.destroy Volume.stat common.py
+GFS2_COMMANDS=Plugin.Query Plugin.diagnostics SR.create SR.ls SR.destroy SR.attach SR.detach SR.stat Volume.create Volume.destroy Volume.stat Volume.snapshot common.py
 LIB_FILES=losetup.py tapdisk.py dmsetup.py nbdclient.py nbdtool.py image.py common.py
 
 .PHONY: clean

--- a/volume/org.xen.xcp.storage.gfs2/Plugin.Query
+++ b/volume/org.xen.xcp.storage.gfs2/Plugin.Query
@@ -13,7 +13,7 @@ class Implementation(xapi.plugin.Plugin_skeleton):
             "copyright": "(C) 2015 Citrix Inc",
             "version": "0.1",
             "required_api_version": "0.1",
-            "features": ["SR_ATTACH", "SR_DETACH", "SR_CREATE", "VDI_CREATE", "VDI_DESTROY", "VDI_ATTACH", "VDI_DETACH", "VDI_ACTIVATE", "VDI_DEACTIVATE", "VDI_UPDATE"],
+            "features": ["SR_ATTACH", "SR_DETACH", "SR_CREATE", "VDI_CREATE", "VDI_DESTROY", "VDI_ATTACH", "VDI_DETACH", "VDI_ACTIVATE", "VDI_DEACTIVATE", "VDI_UPDATE", "VDI_SNAPSHOT"],
             "configuration": {}
         }
 

--- a/volume/org.xen.xcp.storage.gfs2/SR.detach
+++ b/volume/org.xen.xcp.storage.gfs2/SR.detach
@@ -9,7 +9,6 @@ class Implementation(xapi.volume.SR_skeleton):
     def detach(self, dbg, sr):
         u = urlparse.urlparse(sr)
         call(dbg, [ "umount", u.path ])
-        return
 
 if __name__ == "__main__":
     cmd = xapi.volume.SR_commandline(Implementation())

--- a/volume/org.xen.xcp.storage.gfs2/Volume.snapshot
+++ b/volume/org.xen.xcp.storage.gfs2/Volume.snapshot
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+import sys, urlparse, os, errno
+import xapi, xapi.volume
+from common import Lock
+from xapi.common import call
+
+class Implementation(xapi.volume.Volume_skeleton):
+    def snapshot(self, dbg, sr, key):
+        u = urlparse.urlparse(sr)
+        if not(os.path.isdir(u.path)):
+            raise xapi.volume.Sr_not_attached(sr)
+        path = os.path.join(u.path, key)
+        if not(os.path.exists(path)):
+            raise xapi.volume.Volume_does_not_exist(path)
+
+        if key[-4:] == ".vhd":
+            key_noext = key[:-4]
+        else:
+            raise Exception("Unsupported volume type (non-vhd)")
+
+        with Lock(os.path.join(u.path, "%s.lock" % key_noext)):
+            counter = 0
+            key_base = None
+            while key_base is None:
+                if counter > 0:
+                    filename = "%s_base.%d.vhd" % (key_noext, counter)
+                else:
+                    filename = "%s_base.vhd" % key_noext
+                path_base = os.path.join(u.path, filename)
+                try:
+                    fd = os.open(path_base, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                    key_base = filename
+                except OSError as e:
+                    if e.errno != errno.EEXIST:
+                        raise
+                    counter = counter + 1
+            os.close(fd)
+
+            counter = 0
+            key_snap = None
+            while key_snap is None:
+                if counter > 0:
+                    filename = "%s_snap.%d.vhd" % (key_noext, counter)
+                else:
+                    filename = "%s_snap.vhd" % key_noext
+                path_snap = os.path.join(u.path, filename)
+                try:
+                    fd = os.open(path_snap, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                    key_snap = filename
+                except:
+                    if e.errno != errno.EEXIST:
+                        raise
+                    counter = counter + 1
+            os.close(fd)
+
+            os.rename(path, path_base)
+
+            cmd = ["/usr/bin/vhd-util", "snapshot", "-n", path, "-p", path_base]
+            try:
+                call(dbg, cmd)
+            except:
+                os.unlink(path_snap)
+                os.rename(path_base, path)
+                raise
+
+            cmd = ["/usr/bin/vhd-util", "snapshot", "-n", path_snap, "-p", path_base]
+            try:
+                call(dbg, cmd)
+            except:
+                os.unlink(path_snap)
+                os.rename(path_base, path)
+                raise
+
+        cmd = ["/usr/bin/vhd-util", "query", "-n", path_snap, "-v"]
+        stdout = call(dbg, cmd)
+        size = str(int(stdout)*1048576)
+
+        key = "file://" + path_snap
+        return {
+            "key": key_snap,
+            "name": key_snap,
+            "description": "",
+            "read_write": True,
+            "virtual_size": size,
+            "uri": ["vhd+file://" + path_snap ]
+        }
+
+if __name__ == "__main__":
+    cmd = xapi.volume.Volume_commandline(Implementation())
+    cmd.snapshot()

--- a/volume/org.xen.xcp.storage.gfs2/common.py
+++ b/volume/org.xen.xcp.storage.gfs2/common.py
@@ -2,3 +2,12 @@
 
 # For a block device /a/b/c, we will mount it at <mountpoint_root>/a/b/c
 mountpoint_root = "/var/run/sr-mount/"
+
+# FIXME FIXME FIXME FIXME FIXME
+class Lock():
+    def __init__(self, lock_path):
+        self.lock_path = lock_path
+    def __enter__(self):
+        return self.lock_path
+    def __exit__(self, type, value, traceback):
+        return


### PR DESCRIPTION
This adds a vhd-style snapshot operation for the GFS2 SR.

The lock implementation is missing at this point and needs to be fixed.

Signed-off-by: Felipe Franciosi <felipe@paradoxo.org>