### PR TITLE
SR.ls: don't include directories or block devices in the list

### DIFF
--- a/volume/org.xen.xcp.storage.ffs/SR.ls
+++ b/volume/org.xen.xcp.storage.ffs/SR.ls
@@ -13,6 +13,8 @@ class Implementation(xapi.volume.SR_skeleton):
             if filename.endswith(".json"):
                 continue
             path = os.path.join(u.path, filename)
+            if not(os.path.isfile(os.path.realpath(path))):
+                continue
             name = filename
             description = filename
             if os.path.exists(path + ".json"):


### PR DESCRIPTION
We follow the symlink and check the result is a regular file.
Note the .json file should be in the current directory and not the
directory at the far end of the symlink.

Signed-off-by: David Scott <dave.scott@eu.citrix.com>