### PR TITLE
Make SR.attach idempotent

### DIFF
--- a/volume/org.xen.xcp.storage.btrfs/SR.attach
+++ b/volume/org.xen.xcp.storage.btrfs/SR.attach
@@ -24,10 +24,11 @@ class Implementation(xapi.volume.SR_skeleton):
                 pass
             else:
                 raise
-        code = subprocess.call(["mount", "-t", "btrfs", u.path, mountpoint])
-        if code != 0:
-            raise xapi.volume.Unimplemented(
-                "mount -t btrfs %s %s failed" % (u.path, mountpoint))
+        if not os.path.ismount(mountpoint):
+            code = subprocess.call(["mount", "-t", "btrfs", u.path, mountpoint])
+            if code != 0:
+                raise xapi.volume.Unimplemented(
+                    "mount -t btrfs %s %s failed" % (u.path, mountpoint))
         uri = "file://" + mountpoint
         return uri
 

--- a/volume/org.xen.xcp.storage.gfs2/SR.attach
+++ b/volume/org.xen.xcp.storage.gfs2/SR.attach
@@ -35,9 +35,10 @@ class Implementation(xapi.volume.SR_skeleton):
                 pass
             else:
                 raise
-        cmd = ["mount", "-t", "gfs2", "-o",
-               "noatime,nodiratime", u.path, mountpoint]
-        call(dbg, cmd)
+        if not os.path.ismount(mountpoint):
+            cmd = ["mount", "-t", "gfs2", "-o",
+                   "noatime,nodiratime", u.path, mountpoint]
+            call(dbg, cmd)
 
         uri = "file://" + mountpoint
         return uri

--- a/volume/org.xen.xcp.storage.rawnfs/SR.attach
+++ b/volume/org.xen.xcp.storage.rawnfs/SR.attach
@@ -22,12 +22,13 @@ class Implementation(xapi.volume.SR_skeleton):
                 pass
             else:
                 raise
-        cmd = ["mount", "-t", "nfs",
-               "-o", "acdirmin=0,acdirmax=0",
-               u.netloc + ":" + u.path, mountpoint]
-        code = subprocess.call(cmd)
-        if code != 0:
-            raise xapi.volume.Unimplemented(" ".join(cmd) + " failed")
+        if not os.path.ismount(mountpoint):
+            cmd = ["mount", "-t", "nfs",
+                   "-o", "acdirmin=0,acdirmax=0",
+                   u.netloc + ":" + u.path, mountpoint]
+            code = subprocess.call(cmd)
+            if code != 0:
+                raise xapi.volume.Unimplemented(" ".join(cmd) + " failed")
         uri = "file://" + mountpoint
         return uri
 


### PR DESCRIPTION
This means that you can find the current mountpoint of an SR by
calling SR.attach again.

Signed-off-by: David Scott <dave.scott@eu.citrix.com>