### PR TITLE
Fix typo - Drop extra slash in uri returned by sr.ls

### DIFF
--- a/volume/org.xen.xapi.storage.ffs/sr.py
+++ b/volume/org.xen.xapi.storage.ffs/sr.py
@@ -65,7 +65,7 @@ class Implementation(xapi.storage.api.volume.SR_skeleton):
                 "read_write": True,
                 "virtual_size": virtual_size,
                 "physical_utilisation": physical_utilisation,
-                "uri": ["raw+file:///" + path],
+                "uri": ["raw+file://" + path],
                 "keys": keys
             })
         return results


### PR DESCRIPTION
sr.ls() should not return a different uri than volume.create(),
.clone and .snapshot.